### PR TITLE
Retype password page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,7 @@ import './App.css';
 import * as React from 'react';
 import { Route, BrowserRouter, Routes } from "react-router-dom";
 import './App.css';
+import ResetPassword from "./Components/Auth/ResetPassword";
 
 function App() {
   return (
@@ -12,6 +13,7 @@ function App() {
         <Routes>
           <Route path='/signin' element={<UserSignIn />} />
           <Route path='/forgot' element={<ForgotPassword />} />
+          <Route path='/resetpassword' element ={<ResetPassword />}/>
         </Routes>
       </BrowserRouter>
     </div>

--- a/src/App.js
+++ b/src/App.js
@@ -11,9 +11,9 @@ function App() {
     <div>
       <BrowserRouter>
         <Routes>
-          <Route path='/signin' element={<UserSignIn />} />
-          <Route path='/forgot' element={<ForgotPassword />} />
-          <Route path='/resetpassword' element ={<ResetPassword />}/>
+          <Route exact path='/signin' element={<UserSignIn />} />
+          <Route exact path='/forgot' element={<ForgotPassword />} />
+          <Route exact path='/password/reset/confirm/:uid/:token' element={<ResetPassword />} />
         </Routes>
       </BrowserRouter>
     </div>

--- a/src/Components/Auth/ResetPassword.js
+++ b/src/Components/Auth/ResetPassword.js
@@ -6,6 +6,7 @@ import axios from 'axios';
 import Navbar from 'react-bootstrap/Navbar';
 import Form from 'react-bootstrap/Form';
 import TextField from '@mui/material/TextField';
+import { useParams } from 'react-router-dom';
 
 axios.defaults.xsrfCookieName = 'csrftoken';
 axios.defaults.xsrfHeaderName = 'X-CSRFToken';
@@ -17,9 +18,12 @@ function ResetPassword() {
     const [newPassword, setNewPassword] = useState('');
     const [retypeNewPassword, setRetypeNewPassword] = useState('');
 
-    const submitNewPassword = async (e) => {
+    const { uid, token } = useParams();
+
+    const submitNewPassword = (e) => {
         e.preventDefault();
-        await AuthService.resetPasswordConfirm(newPassword, setNewPassword);
+
+        AuthService.resetPasswordConfirm(uid, token, newPassword, retypeNewPassword);
     }
 
     return (
@@ -30,7 +34,7 @@ function ResetPassword() {
                     Password
                 </div>
                 <Navbar bg="dark" variant="dark">
-                    <Form onSubmit={ e => submitNewPassword(e)}>
+                    <Form onSubmit={e => submitNewPassword(e)}>
                         <div className="email-field">
                             <Box sx={{
                                 borderRadius: 1,
@@ -45,7 +49,7 @@ function ResetPassword() {
                                     onChange={e => setNewPassword(e.target.vaue)}
                                     fullWidth
                                     sx={{ '& fieldset': { borderColor: 'transparent' } }}
-                                    // underline={false}
+                                // underline={false}
                                 />
                             </Box>
                         </div>
@@ -63,7 +67,7 @@ function ResetPassword() {
                                 onChange={e => setRetypeNewPassword(e.target.vaue)}
                                 fullWidth
                                 sx={{ '& fieldset': { borderColor: 'transparent' } }}
-                                // underline={false}
+                            // underline={false}
                             />
                         </Box>
                         <div className='sign-in-button'>

--- a/src/Components/Auth/ResetPassword.js
+++ b/src/Components/Auth/ResetPassword.js
@@ -6,26 +6,35 @@ import axios from 'axios';
 import Navbar from 'react-bootstrap/Navbar';
 import Form from 'react-bootstrap/Form';
 import TextField from '@mui/material/TextField';
-import { useParams } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 
 axios.defaults.xsrfCookieName = 'csrftoken';
 axios.defaults.xsrfHeaderName = 'X-CSRFToken';
 axios.defaults.withCredentials = true;
 function ResetPassword() {
 
+    let navigate = useNavigate();
     // create const useState for message and new_password
     const [message, setMessage] = useState('');
     const [new_password, setNewPassword] = useState('');
     const [retypeNewPassword, setRetypeNewPassword] = useState('');
+    const [submitting, setSubmitting] = useState(false);
 
     const { uid, token } = useParams();
 
     const submitNewPassword = (e) => {
         e.preventDefault();
-
-        AuthService.resetPasswordConfirm(uid, token, new_password, retypeNewPassword);
-    }
-
+            setSubmitting(true);
+            AuthService.resetPasswordConfirm(uid, token, new_password, retypeNewPassword)
+            .then(() => {
+                // this does not reached
+                setMessage('Password has been changed! Please log-in with new password');
+                setSubmitting(false);
+            }).then(() => {
+                // so far after reset, it will return to sign in page.
+                navigate('/signin')
+            })
+        }
     
     return (
         <div className="container">

--- a/src/Components/Auth/ResetPassword.js
+++ b/src/Components/Auth/ResetPassword.js
@@ -1,4 +1,6 @@
 import './UserSignIn.css';
+import AuthService from '../services/Auth.server';
+import { useState } from 'react';
 import { Button, Box } from '@mui/material';
 import axios from 'axios';
 import Navbar from 'react-bootstrap/Navbar';
@@ -10,7 +12,15 @@ axios.defaults.xsrfHeaderName = 'X-CSRFToken';
 axios.defaults.withCredentials = true;
 function ResetPassword() {
 
+    // create const useState for message and new_password
+    const [message, setMessage] = useState('');
+    const [newPassword, setNewPassword] = useState('');
+    const [retypeNewPassword, setRetypeNewPassword] = useState('');
 
+    const submitNewPassword = async (e) => {
+        e.preventDefault();
+        await AuthService.resetPasswordConfirm(newPassword, setNewPassword);
+    }
 
     return (
         <div className="container">
@@ -20,7 +30,7 @@ function ResetPassword() {
                     Password
                 </div>
                 <Navbar bg="dark" variant="dark">
-                    <Form >
+                    <Form onSubmit={ e => submitNewPassword(e)}>
                         <div className="email-field">
                             <Box sx={{
                                 borderRadius: 1,
@@ -31,6 +41,8 @@ function ResetPassword() {
                                 <TextField
                                     id="new-password"
                                     label="New Passsword"
+                                    value={newPassword}
+                                    onChange={e => setNewPassword(e.target.vaue)}
                                     fullWidth
                                     sx={{ '& fieldset': { borderColor: 'transparent' } }}
                                     // underline={false}
@@ -47,6 +59,8 @@ function ResetPassword() {
                                 id="re-password"
                                 label="Re-type Password"
                                 type="password"
+                                value={retypeNewPassword}
+                                onChange={e => setRetypeNewPassword(e.target.vaue)}
                                 fullWidth
                                 sx={{ '& fieldset': { borderColor: 'transparent' } }}
                                 // underline={false}

--- a/src/Components/Auth/ResetPassword.js
+++ b/src/Components/Auth/ResetPassword.js
@@ -1,0 +1,70 @@
+import './UserSignIn.css';
+import { Button, Box } from '@mui/material';
+import axios from 'axios';
+import Navbar from 'react-bootstrap/Navbar';
+import Form from 'react-bootstrap/Form';
+import TextField from '@mui/material/TextField';
+
+axios.defaults.xsrfCookieName = 'csrftoken';
+axios.defaults.xsrfHeaderName = 'X-CSRFToken';
+axios.defaults.withCredentials = true;
+function ResetPassword() {
+
+
+
+    return (
+        <div className="container">
+            <div className="container-form">
+                <img src="https://www.isods.org//images/isods_small_logo.png" alt="Profile Picture" id="profile-picture" />
+                <div className="sign-in-header">
+                    Password
+                </div>
+                <Navbar bg="dark" variant="dark">
+                    <Form >
+                        <div className="email-field">
+                            <Box sx={{
+                                borderRadius: 1,
+                                padding: '2px 6px',
+                                boxShadow: '2px 2px 4px rgba(0, 0, 0, 0.25)',
+                                width: '100%',
+                            }}>
+                                <TextField
+                                    id="new-password"
+                                    label="New Passsword"
+                                    fullWidth
+                                    sx={{ '& fieldset': { borderColor: 'transparent' } }}
+                                    // underline={false}
+                                />
+                            </Box>
+                        </div>
+                        <Box sx={{
+                            borderRadius: 1,
+                            padding: '2px 6px',
+                            boxShadow: '2px 2px 4px rgba(0, 0, 0, 0.25)',
+                            marginTop: '1rem',
+                        }}>
+                            <TextField
+                                id="re-password"
+                                label="Re-type Password"
+                                type="password"
+                                fullWidth
+                                sx={{ '& fieldset': { borderColor: 'transparent' } }}
+                                // underline={false}
+                            />
+                        </Box>
+                        <div className='sign-in-button'>
+                            <Button variant="contained" type="submit">
+                                Submit
+                            </Button>
+                        </div>
+                    </Form>
+                </Navbar>
+            </div>
+            <div className="goback-button">
+                <a href="/"> « BACK</a>
+            </div>
+        </div>
+    );
+}
+
+export default ResetPassword;

--- a/src/Components/Auth/ResetPassword.js
+++ b/src/Components/Auth/ResetPassword.js
@@ -15,7 +15,7 @@ function ResetPassword() {
 
     // create const useState for message and new_password
     const [message, setMessage] = useState('');
-    const [newPassword, setNewPassword] = useState('');
+    const [new_password, setNewPassword] = useState('');
     const [retypeNewPassword, setRetypeNewPassword] = useState('');
 
     const { uid, token } = useParams();
@@ -23,9 +23,10 @@ function ResetPassword() {
     const submitNewPassword = (e) => {
         e.preventDefault();
 
-        AuthService.resetPasswordConfirm(uid, token, newPassword, retypeNewPassword);
+        AuthService.resetPasswordConfirm(uid, token, new_password, retypeNewPassword);
     }
 
+    
     return (
         <div className="container">
             <div className="container-form">
@@ -43,10 +44,11 @@ function ResetPassword() {
                                 width: '100%',
                             }}>
                                 <TextField
-                                    id="new-password"
+                                    id="new_password"
                                     label="New Passsword"
-                                    value={newPassword}
-                                    onChange={e => setNewPassword(e.target.vaue)}
+                                    type="password"
+                                    value={new_password}
+                                    onChange={e => setNewPassword(e.target.value)}
                                     fullWidth
                                     sx={{ '& fieldset': { borderColor: 'transparent' } }}
                                 // underline={false}
@@ -60,11 +62,11 @@ function ResetPassword() {
                             marginTop: '1rem',
                         }}>
                             <TextField
-                                id="re-password"
+                                id="re_new_password"
                                 label="Re-type Password"
                                 type="password"
                                 value={retypeNewPassword}
-                                onChange={e => setRetypeNewPassword(e.target.vaue)}
+                                onChange={e => setRetypeNewPassword(e.target.value)}
                                 fullWidth
                                 sx={{ '& fieldset': { borderColor: 'transparent' } }}
                             // underline={false}

--- a/src/Components/services/Auth.server.js
+++ b/src/Components/services/Auth.server.js
@@ -29,16 +29,22 @@ const logout = () => {
     localStorage.removeItem("User");
 }
 
+
 const resetPasswordConfirm = (uid, token, new_password, re_new_password) => {
-    return axios.post(`${API_URL_USERS}/reset_password_confirm/`, {
-        uid,
-    });
+    const config = {
+        headers: {
+            'Content-Type': 'application/json'
+        }
+    }
+    const body = JSON.stringify({uid, token, new_password, re_new_password});
+    return axios.post(`${API_URL_USERS}/reset_password_confirm/`, body);
 }
 
 const authService = {
     login,
     requestEmail,
     logout,
+    resetPasswordConfirm,
 };
 
 export default authService;

--- a/src/Components/services/Auth.server.js
+++ b/src/Components/services/Auth.server.js
@@ -29,6 +29,12 @@ const logout = () => {
     localStorage.removeItem("User");
 }
 
+const resetPasswordConfirm = (uid, token, new_password, re_new_password) => {
+    return axios.post(`${API_URL_USERS}/reset_password_confirm/`, {
+        uid,
+    });
+}
+
 const authService = {
     login,
     requestEmail,

--- a/src/Components/services/Auth.server.js
+++ b/src/Components/services/Auth.server.js
@@ -37,7 +37,7 @@ const resetPasswordConfirm = (uid, token, new_password, re_new_password) => {
         }
     }
     const body = JSON.stringify({uid, token, new_password, re_new_password});
-    return axios.post(`${API_URL_USERS}/reset_password_confirm/`, body);
+    return axios.post(`${API_URL_USERS}/reset_password_confirm/`, body, config);
 }
 
 const authService = {


### PR DESCRIPTION
# What does this PR solve and how
## What is this PR about?
- Implementation of Re-type-password Frontend Page. 

## How to run it step by step
Step 1: Run application : Yarn start

Step 2: Access to this URL, send a request to Backend (if you have an account with us).
```curl
curl --location 'http://127.0.0.1:3000/forgot
```

Step 3: A link will be sent to your email, and set your new password.
```curl
curl --location 'http://127.0.0.1:3000/password/reset/confirm/:uid/:token
```

# Implementation 

Add any implementation details
- Hide complexity of Implementation on Auth.server.js.
- Backend needs params: uid, token, new_password, re_new_password. 
- So Frontend will have an arrow function with those above params (resetPasswordConfirm).
- Specify headers, and body to make sure when FE sending request with data to BE.
- Using Axios.post to send request to Backend.
- Using useParams() to extract uid and token from URL and pass it to the arrow function created above (resetPasswordConfirm).

# Testing
- Manually test with a legit email in database 
- If your database doesn't have the email, it won't send reset link to the email you put.
- Also when you create email in your database. You must use Postman to activate your email.
- I will develop that feature asap.

# Risk
- None

# Dependencies
- Use a few hooks from React.
- No dependencies injected. 

# PR Checklist
- [x] Documentation
- [x] Unit testing passed
- [ ] Code review and discussion
- [ ] Approve
- [ ] Merge
